### PR TITLE
Fix/63 refactor UI dropdown

### DIFF
--- a/src/components/ui/dropDownUI.tsx
+++ b/src/components/ui/dropDownUI.tsx
@@ -10,6 +10,7 @@ interface DropDownProps {
   label?: string; // 제목
   list: string[]; // 드롭다운 리스트
   selected: string; // 선택된 항목(selected state)
+  dropDownPlaceHolder?: string; // 드롭다운 플레이스홀더
   handleSelectedChange: (selected: string) => void; // 선택된 항목 변경 함수(selected setState 변경 함수)
   description?: string; // 드롭다운 설명
 }
@@ -18,6 +19,7 @@ export default function DropDownCommon({
   label,
   list,
   selected,
+  dropDownPlaceHolder,
   handleSelectedChange,
   description,
 }: DropDownProps) {
@@ -42,7 +44,7 @@ export default function DropDownCommon({
       <S.DropdownContainer>
         <S.DropdownBody onClick={toggleDropdown} isActive={isActive}>
           <S.DropdownSelected>
-            {selected || "Select an item"}
+            {selected || dropDownPlaceHolder || "Select an item"}
           </S.DropdownSelected>
           <S.DropdownSelected>
             <Image

--- a/src/components/ui/dropDownUI.tsx
+++ b/src/components/ui/dropDownUI.tsx
@@ -36,7 +36,7 @@ export default function DropDownCommon({
 
   return (
     <S.Container>
-      {label && <S.DropDownLabel>{label}</S.DropDownLabel>}
+      {label && <S.DropDownLabel disabled={disabled}>{label}</S.DropDownLabel>}
       <S.DropdownContainer>
         <S.DropdownBody
           onClick={toggleDropdown}
@@ -80,11 +80,12 @@ const S = {
     display: flex;
     flex-direction: column;
   `,
-  DropDownLabel: styled.label`
+  DropDownLabel: styled.label<{ disabled: boolean }>`
     margin-bottom: 8px;
     font-size: 16px;
     font-weight: 700;
-    color: ${({ theme }) => theme.color.gray700};
+    color: ${({ theme, disabled }) =>
+      disabled ? theme.color.gray500 : theme.color.gray700};
   `,
   DropdownContainer: styled.div`
     position: relative;

--- a/src/components/ui/dropDownUI.tsx
+++ b/src/components/ui/dropDownUI.tsx
@@ -9,7 +9,7 @@ interface StyledInputProps {
 interface DropDownProps {
   label?: string; // 제목
   list: string[]; // 드롭다운 리스트
-  selected: string; // 선택된 항목(selected state)
+  selected?: string; // 선택된 항목(selected state)
   dropDownPlaceHolder?: string; // 드롭다운 플레이스홀더
   handleSelectedChange: (selected: string) => void; // 선택된 항목 변경 함수(selected setState 변경 함수)
   description?: string; // 드롭다운 설명
@@ -29,8 +29,8 @@ export default function DropDownCommon({
     setIsActive(!isActive);
   };
 
-  const handleSelect = (item: string) => {
-    handleSelectedChange(item);
+  const handleSelect = (selected: string) => {
+    handleSelectedChange(selected);
     setIsActive(false);
   };
 
@@ -62,7 +62,7 @@ export default function DropDownCommon({
               key={item}
               isSelected={item === selected}
               onClick={() => {
-                handleSelect(selected);
+                handleSelect(item);
               }}
             >
               {item}

--- a/src/components/ui/dropDownUI.tsx
+++ b/src/components/ui/dropDownUI.tsx
@@ -2,14 +2,10 @@ import React, { useState, useCallback } from "react";
 import styled from "styled-components";
 import Image from "next/image";
 
-interface StyledInputProps {
-  isActive: boolean;
-}
-
 interface DropDownProps {
   label?: string; // 제목
   list: string[]; // 드롭다운 리스트
-  selected?: string; // 선택된 항목(selected state)
+  selected: string; // 선택된 항목(selected state)
   dropDownPlaceHolder?: string; // 드롭다운 플레이스홀더
   handleSelectedChange: (selected: string) => void; // 선택된 항목 변경 함수(selected setState 변경 함수)
   description?: string; // 드롭다운 설명
@@ -33,8 +29,8 @@ export default function DropDownCommon({
     }
   };
 
-  const handleSelect = (selected: string) => {
-    handleSelectedChange(selected);
+  const handleSelect = (item: string) => {
+    handleSelectedChange(item);
     setIsActive(false);
   };
 
@@ -47,10 +43,10 @@ export default function DropDownCommon({
           isActive={isActive}
           disabled={disabled}
         >
-          <S.DropdownSelected disabled={disabled}>
+          <S.DropdownSelected disabled={disabled} selected={selected}>
             {selected || dropDownPlaceHolder || "Select an item"}
           </S.DropdownSelected>
-          <S.DropdownSelected disabled={false}>
+          <S.DropdownSelected disabled={false} selected={selected}>
             <Image
               src="/auth/arrow_down.svg"
               alt="arrow"
@@ -110,13 +106,17 @@ const S = {
     cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
     border-radius: 8px;
   `,
-  DropdownSelected: styled.div<{ disabled: boolean }>`
+  DropdownSelected: styled.div<{ disabled: boolean; selected: string }>`
     font-size: 16px;
-    color: ${({ theme, disabled }) =>
-      disabled ? theme.color.gray600 : theme.color.gray900};
+    color: ${({ theme, disabled, selected }) =>
+      disabled
+        ? theme.color.gray500
+        : selected
+        ? theme.color.gray900
+        : theme.color.gray500};
     padding: 14px 16px;
   `,
-  DropdownMenuContainer: styled.ul<StyledInputProps>`
+  DropdownMenuContainer: styled.ul<{ isActive: boolean }>`
     position: absolute;
     top: calc(100% + 8px);
     left: 0;

--- a/src/components/ui/dropDownUI.tsx
+++ b/src/components/ui/dropDownUI.tsx
@@ -7,7 +7,7 @@ interface StyledInputProps {
 }
 
 interface DropDownProps {
-  label: string; // 제목
+  label?: string; // 제목
   list: string[]; // 드롭다운 리스트
   selected: string; // 선택된 항목(selected state)
   onSelectedChange: (selected: string) => void; // 선택된 항목 변경 함수(selected setState 변경 함수)

--- a/src/components/ui/dropDownUI.tsx
+++ b/src/components/ui/dropDownUI.tsx
@@ -153,21 +153,36 @@ const S = {
 };
 
 // EXAMPLE : 아래처럼 사용하세요!!(src/pages/test.tsx)
-// export default function Test() {
-//   const [selected, setSelected] = useState("Republic of Korea");
-//   const onSelectedChange = useCallback((selected: string) => {
-//     setSelected(selected);
-//   }, []);
+// import { useState } from "react";
+// import { Margin } from "../components/ui";
+// import DropDown from "../components/ui/dropDownUI";
+// import styled from "styled-components";
 
-//   const list = [
-//     "Republic of Korea",
-//     "United States of America",
-//     "Canada",
-//     "China",
-//     "Japan",
-//     "Russia",
-//     "France",
-//     "Germany",
+// export default function Test() {
+//   const [selected, setSelected] = useState<string>("REPUBLIC OF KOREA");
+//   const handleSelectedChange = (selected: string) => {
+//     setSelected(selected);
+//   };
+
+//   const countryList = [
+//     {
+//       code: "KR",
+//       nation: "대한민국",
+//       add_code_nation: "KR 대한민국",
+//       country: "REPUBLIC OF KOREA",
+//     },
+//     {
+//       code: "CN",
+//       nation: "중화인민공화국",
+//       add_code_nation: "CN 중화인민공화국",
+//       country: "CHINA",
+//     },
+//     {
+//       code: "VN",
+//       nation: "베트남",
+//       add_code_nation: "VN 베트남",
+//       country: "VIET NAM",
+//     },
 //   ];
 
 //   return (
@@ -177,9 +192,9 @@ const S = {
 //         <Margin size={8} direction="row" />
 //         <DropDown
 //           label="안녕"
-//           list={list}
+//           list={countryList.map((item) => item.country)}
 //           selected={selected}
-//           onSelectedChange={onSelectedChange}
+//           handleSelectedChange={handleSelectedChange}
 //           description="테스트"
 //         />
 //       </div>

--- a/src/components/ui/dropDownUI.tsx
+++ b/src/components/ui/dropDownUI.tsx
@@ -13,6 +13,7 @@ interface DropDownProps {
   dropDownPlaceHolder?: string; // 드롭다운 플레이스홀더
   handleSelectedChange: (selected: string) => void; // 선택된 항목 변경 함수(selected setState 변경 함수)
   description?: string; // 드롭다운 설명
+  disabled?: boolean; // 드롭다운 비활성화
 }
 
 export default function DropDownCommon({
@@ -22,11 +23,14 @@ export default function DropDownCommon({
   dropDownPlaceHolder,
   handleSelectedChange,
   description,
+  disabled = false,
 }: DropDownProps) {
   const [isActive, setIsActive] = useState(false);
 
   const toggleDropdown = () => {
-    setIsActive(!isActive);
+    if (!disabled) {
+      setIsActive(!isActive);
+    }
   };
 
   const handleSelect = (selected: string) => {
@@ -34,19 +38,19 @@ export default function DropDownCommon({
     setIsActive(false);
   };
 
-  // TODO: 여기 리팩토링 필요함. 이게 원래 innerText를 그대로 넣는 건데, country 객체 데이터가 변경됨에 따라 확장성이 더 필요해졌음
-  // 그래서 이제는 country 객체 데이터를 받아서, country 객체 데이터의 code을 innerText로 찾아서 넣는 방식으로 변경됨에 따라
-  // onSelectedChange를 Props로 받는 게 아닌 내장된 handleSelectItem을 없애고 handleSelectItem을 Props로 받는 것이 맞는 거 같다..
-
   return (
     <S.Container>
       {label && <S.DropDownLabel>{label}</S.DropDownLabel>}
       <S.DropdownContainer>
-        <S.DropdownBody onClick={toggleDropdown} isActive={isActive}>
-          <S.DropdownSelected>
+        <S.DropdownBody
+          onClick={toggleDropdown}
+          isActive={isActive}
+          disabled={disabled}
+        >
+          <S.DropdownSelected disabled={disabled}>
             {selected || dropDownPlaceHolder || "Select an item"}
           </S.DropdownSelected>
-          <S.DropdownSelected>
+          <S.DropdownSelected disabled={false}>
             <Image
               src="/auth/arrow_down.svg"
               alt="arrow"
@@ -92,21 +96,24 @@ const S = {
       cursor: pointer;
     }
   `,
-  DropdownBody: styled.div<{ isActive: boolean }>`
+  DropdownBody: styled.div<{ disabled: boolean; isActive: boolean }>`
     display: flex;
     justify-content: space-between;
     align-items: center;
     width: 452px;
     height: 50px;
-    background-color: ${({ theme }) => theme.color.white};
+    background-color: ${({ theme, disabled }) =>
+      disabled ? theme.color.gray200 : theme.color.white};
     border: 1px solid
       ${({ theme, isActive }) =>
-        isActive ? theme.color.gray600 : theme.color.gray300};
+        isActive ? theme.color.gray600 : theme.color.gray200};
+    cursor: ${({ disabled }) => (disabled ? "not-allowed" : "pointer")};
     border-radius: 8px;
   `,
-  DropdownSelected: styled.div`
+  DropdownSelected: styled.div<{ disabled: boolean }>`
     font-size: 16px;
-    color: ${({ theme }) => theme.color.gray900};
+    color: ${({ theme, disabled }) =>
+      disabled ? theme.color.gray600 : theme.color.gray900};
     padding: 14px 16px;
   `,
   DropdownMenuContainer: styled.ul<StyledInputProps>`

--- a/src/components/ui/dropDownUI.tsx
+++ b/src/components/ui/dropDownUI.tsx
@@ -167,7 +167,8 @@ const S = {
 // import styled from "styled-components";
 
 // export default function Test() {
-//   const [selected, setSelected] = useState<string>("REPUBLIC OF KOREA");
+//   const [selected, setSelected] = useState<string>("");
+//   // const [isButtonDisabled, setButtonDisabled] = useState<boolean>(true);
 //   const handleSelectedChange = (selected: string) => {
 //     setSelected(selected);
 //   };
@@ -202,6 +203,8 @@ const S = {
 //           label="안녕"
 //           list={countryList.map((item) => item.country)}
 //           selected={selected}
+//           dropDownPlaceHolder="선택하세요"
+//           // disabled={isButtonDisabled}
 //           handleSelectedChange={handleSelectedChange}
 //           description="테스트"
 //         />

--- a/src/components/ui/dropDownUI.tsx
+++ b/src/components/ui/dropDownUI.tsx
@@ -10,42 +10,40 @@ interface DropDownProps {
   label?: string; // 제목
   list: string[]; // 드롭다운 리스트
   selected: string; // 선택된 항목(selected state)
-  onSelectedChange: (selected: string) => void; // 선택된 항목 변경 함수(selected setState 변경 함수)
+  handleSelectedChange: (selected: string) => void; // 선택된 항목 변경 함수(selected setState 변경 함수)
   description?: string; // 드롭다운 설명
 }
 
-export default function DropDown({
+export default function DropDownCommon({
   label,
   list,
   selected,
-  onSelectedChange,
+  handleSelectedChange,
   description,
 }: DropDownProps) {
   const [isActive, setIsActive] = useState(false);
 
-  const onActiveToggle = useCallback(() => {
-    setIsActive((prev) => !prev);
-  }, []);
+  const toggleDropdown = () => {
+    setIsActive(!isActive);
+  };
+
+  const handleSelect = (item: string) => {
+    handleSelectedChange(item);
+    setIsActive(false);
+  };
 
   // TODO: 여기 리팩토링 필요함. 이게 원래 innerText를 그대로 넣는 건데, country 객체 데이터가 변경됨에 따라 확장성이 더 필요해졌음
   // 그래서 이제는 country 객체 데이터를 받아서, country 객체 데이터의 code을 innerText로 찾아서 넣는 방식으로 변경됨에 따라
-  // onSelectedChange를 Props로 받는 게 아닌 내장된 handleSelectItem을 없애고 Props로 받는 것이 맞는 거 같다..
-  const handleSelectItem: React.MouseEventHandler<HTMLLIElement> = useCallback(
-    (e) => {
-      const target = e.target as HTMLLIElement;
-      const selectedNation = target.innerText;
-      onSelectedChange(selectedNation);
-      setIsActive(false);
-    },
-    [onSelectedChange]
-  );
+  // onSelectedChange를 Props로 받는 게 아닌 내장된 handleSelectItem을 없애고 handleSelectItem을 Props로 받는 것이 맞는 거 같다..
 
   return (
     <S.Container>
-      <S.Label>{label}</S.Label>
+      {label && <S.DropDownLabel>{label}</S.DropDownLabel>}
       <S.DropdownContainer>
-        <S.DropdownBody onClick={onActiveToggle} isActive={isActive}>
-          <S.DropdownSelected>{selected}</S.DropdownSelected>
+        <S.DropdownBody onClick={toggleDropdown} isActive={isActive}>
+          <S.DropdownSelected>
+            {selected || "Select an item"}
+          </S.DropdownSelected>
           <S.DropdownSelected>
             <Image
               src="/auth/arrow_down.svg"
@@ -61,7 +59,9 @@ export default function DropDown({
             <S.DropdownItemContainer
               key={item}
               isSelected={item === selected}
-              onClick={handleSelectItem}
+              onClick={() => {
+                handleSelect(selected);
+              }}
             >
               {item}
             </S.DropdownItemContainer>
@@ -78,7 +78,7 @@ const S = {
     display: flex;
     flex-direction: column;
   `,
-  Label: styled.label`
+  DropDownLabel: styled.label`
     margin-bottom: 8px;
     font-size: 16px;
     font-weight: 700;

--- a/src/pages/auth/signup.tsx
+++ b/src/pages/auth/signup.tsx
@@ -14,10 +14,6 @@ import { signUpFormDataAtom } from "@/src/atoms/auth/signUpAtoms";
 import { useRecoilValue } from "recoil";
 import { SignUpFormData } from "@/src/types/auth/signupFormDataType";
 
-interface SdInputProps {
-  disabled: boolean;
-}
-
 export default function SignUp() {
   const [isButtonDisabled, setButtonDisabled] = useState(true);
 
@@ -90,7 +86,7 @@ const S = {
   BackButton: styled(Image)`
     cursor: pointer;
   `,
-  CompleteButton: styled.button<SdInputProps>`
+  CompleteButton: styled.button<{ disabled: boolean }>`
     background-color: ${({ disabled }) => (disabled ? "#EEEEF2" : "#FF812E")};
     color: ${({ disabled }) => (disabled ? "#959599" : "#fff")};
     border-radius: 8px;

--- a/src/pages/auth/signup.tsx
+++ b/src/pages/auth/signup.tsx
@@ -30,6 +30,8 @@ export default function SignUp() {
       signUpFormData.termsOfPersonalInformation
     ) {
       setButtonDisabled(false);
+    } else {
+      setButtonDisabled(true);
     }
   }, [signUpFormData]);
 

--- a/src/types/countryList.ts
+++ b/src/types/countryList.ts
@@ -1,0 +1,6 @@
+export type CountryListType = {
+  code: string;
+  nation: string;
+  add_code_nation: string;
+  country: string;
+};


### PR DESCRIPTION
## PR 내용
공통 UI dropdown을 더 확장할 수 있게 수정

## branch
- [x] feat -> develop

## 리뷰
드롭다운을 사용하는데에 애로사항이 생겨 수정이 들어갔습니다.

1. label의 선택 옵션화
2. disabled의 조건 추가 : `DropDownLabel`, `DropdownBody`, `DropdownSelected`에 추가하여 클릭 금지 및 UI적으로 표사
3. placeholder 추가 : `dropDownPlaceHolder`를 추가하여 `selected`가 빈값이라면 나타낼 장치 추가, 기본값 : "Select an item"
4. 드롭다운 setter 함수를 받는 방식이 onSelectedChange에서 handleSelectedChange로 바뀜
```tsx
  const handleSelectItem: React.MouseEventHandler<HTMLLIElement> = useCallback(
    (e) => {
      const target = e.target as HTMLLIElement;
      const selectedNation = target.innerText;
      onSelectedChange(selectedNation);
      setIsActive(false);
    },
    [onSelectedChange]
  );
  ```
  이 방식으로 내장돼 있었고, Props로 `onSelectedChange`를 받았는데,  유나님이 말씀해주신 국가리스트를 바로 받고, 리스트로 값을 바꿔주는 로직을 짜라고 해주셔서 `handleSelectItem`를 아예 빼고 Props로 넣음
드롭다운 UI 코드 파일 안 맨 아래에 있는 `EXAMPLE` 부분을 보면 알겠지만 공통 UI 파일 안에 작성하는 것이 아닌 상태나 아톰 setter 함수들을 받는 `handleSelectedChange`를 그대로 Props에 넣었음

  
