### PR TITLE
Feature/68page routing

### DIFF
--- a/src/hooks/useRedirectToMain.ts
+++ b/src/hooks/useRedirectToMain.ts
@@ -4,17 +4,20 @@ import { getRefreshTokenFromLocalStorage } from "../utils/refreshTokenHandler";
 
 export const useRedirectToMain = () => {
   const router = useRouter();
-  console.log(router.pathname, router.query);
   useEffect(() => {
     if (
       router.pathname !== "/auth/login" &&
-      router.pathname !== "/auth/signup"
+      router.pathname !== "/auth/signup" &&
+      router.pathname !== "/admin"
     ) {
       const checkLogined = () => {
         const logined = getRefreshTokenFromLocalStorage();
         if (!logined) {
           alert("로그인이 필요합니다.");
           router.replace("/auth/login");
+          setTimeout(() => {
+            window.location.reload();
+          }, 1000);
         }
       };
       checkLogined();

--- a/src/hooks/useRedirectToMain.ts
+++ b/src/hooks/useRedirectToMain.ts
@@ -1,0 +1,23 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { getRefreshTokenFromLocalStorage } from "../utils/refreshTokenHandler";
+
+export const useRedirectToMain = () => {
+  const router = useRouter();
+  console.log(router.pathname, router.query);
+  useEffect(() => {
+    if (
+      router.pathname !== "/auth/login" &&
+      router.pathname !== "/auth/signup"
+    ) {
+      const checkLogined = () => {
+        const logined = getRefreshTokenFromLocalStorage();
+        if (!logined) {
+          alert("로그인이 필요합니다.");
+          router.replace("/auth/login");
+        }
+      };
+      checkLogined();
+    }
+  }, []);
+};

--- a/src/hooks/useRedirectToMain.ts
+++ b/src/hooks/useRedirectToMain.ts
@@ -15,9 +15,6 @@ export const useRedirectToMain = () => {
         if (!logined) {
           alert("로그인이 필요합니다.");
           router.replace("/auth/login");
-          setTimeout(() => {
-            window.location.reload();
-          }, 1000);
         }
       };
       checkLogined();

--- a/src/hooks/useRedirectToMain.ts
+++ b/src/hooks/useRedirectToMain.ts
@@ -2,7 +2,7 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { getRefreshTokenFromLocalStorage } from "../utils/refreshTokenHandler";
 
-export const useRedirectToMain = () => {
+export const useRedirectToMain = (): void => {
   const router = useRouter();
   useEffect(() => {
     if (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,7 +7,8 @@ import { RecoilRoot } from "recoil";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { useState } from "react";
 import styled from "styled-components";
-import useAppVersion from '../hooks/useAppVersion';
+import useAppVersion from "../hooks/useAppVersion";
+import { useRedirectToMain } from "../hooks/useRedirectToMain";
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   const version = useAppVersion();
@@ -26,6 +27,8 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         },
       })
   );
+
+  useRedirectToMain();
 
   return (
     <>
@@ -52,15 +55,14 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 }
 
 const S = {
-  Wrapper: styled.div<{version: string}>`
-    ${props => props.version === 'mobile' && 
+  Wrapper: styled.div<{ version: string }>`
+    ${(props) =>
+      props.version === "mobile" &&
       css`
         width: 500px;
         max-width: 500px;
         min-height: 100vh;
         background-color: white;
-        `
-      }
-  `
-
+      `}
+  `,
 };

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -23,10 +23,10 @@ export default function Admin() {
 
   return (
     <S.Main>
-      <Header />
-      <Tabbar currIdx={currIdx} handleClickTabBar={handleClickTabBar} />
       {data && (
         <>
+          <Header />
+          <Tabbar currIdx={currIdx} handleClickTabBar={handleClickTabBar} />
           <Content data={data.data.list} />
           <PageBtn
             totalPages={data.data.totalPages}


### PR DESCRIPTION
## PR 내용
- 리프레쉬 토큰이 없을 경우 로그인 페이지로 이동


## branch
- [x] feat -> develop
- [ ] develop -> main



## 리뷰
- 커스텀 훅으로 리프레쉬 토큰 값 여부를 체크해서 없는 경우 로그인 페이지로 이동하도록 했고 _app.tsx 파일에 호출하는 식으로 구현했습니다. getServerSideProps도 고려해봤는데 cookie는 server side에서도 접근 가능한데 localstorage는 client side 쪽에서만 접근 가능해서 안되더라고요 혹시 더 좋은 방법 있으면 알려주세요~~
- admin 페이지 접근 권한은 이미 해놔주신 상태였는데, 권한 없을 때 이동했을 경우 header랑 tabbar 컴포넌트까지 보여지고 이동되더라고요! 아예 안 보여지는게 나을 것 같아서 data 체크 위치를 조금 수정하는 식으로 했는데 이것도 혹시 더 나은 방법 있으면 알려주세요!