### PR TITLE
feat : 리턴 타입 추가,profile 페이지 추가,닉네임 중복시 알람창 추가

### DIFF
--- a/src/api/mypage/profileData.ts
+++ b/src/api/mypage/profileData.ts
@@ -8,26 +8,26 @@ export const getProfile = async (): Promise<ProfileStateType> => {
   return data;
 };
 
-export const postIntroduce =async (introduce:string) => {
-  const response =  await instance.post("/profile/introduction", {
-     "introduction" : introduce
-  });
-
-  return response.data;
-}
-
-export const postLanguage = async (language: String[]): Promise<void> => {
-  const response = await instance.post("/profile/languages", {
-    "languages": language.filter(v=>v!=='')
+export const postIntroduce = async (introduce: string): Promise<void> => {
+  const response = await instance.post("/profile/introduction", {
+    introduction: introduce,
   });
 
   return response.data;
 };
 
-export const postInterest = async (interest : String[] ): Promise<void> => {
-  const response =  await instance.post("/profile/interests", {
-    "interests": interest
-  })
+export const postLanguage = async (language: string[]): Promise<void> => {
+  const response = await instance.post("/profile/languages", {
+    languages: language.filter((v) => v !== ""),
+  });
+
+  return response.data;
+};
+
+export const postInterest = async (interest: string[]): Promise<void> => {
+  const response = await instance.post("/profile/interests", {
+    interests: interest,
+  });
 
   return response.data;
 };

--- a/src/api/mypage/updateProfile.ts
+++ b/src/api/mypage/updateProfile.ts
@@ -1,7 +1,8 @@
 import { ProfileUpdateType } from "@/src/types/mypage/profileType";
+import { NextApiResponse } from "next";
 import instance from "../axiosModule";
 
-const withFormData = (data: ProfileUpdateType) => {
+const withFormData = (data: ProfileUpdateType): FormData => {
   const formData = new FormData();
   Object.entries(data).forEach(([key, value]) => {
     if (typeof value === "boolean") {
@@ -22,7 +23,7 @@ const withFormData = (data: ProfileUpdateType) => {
 
 export const postUpdateProfile = async (
   profileUpdateData: ProfileUpdateType
-) => {
+): Promise<NextApiResponse> => {
   const response = await instance.post(
     "/profile",
     withFormData(profileUpdateData),

--- a/src/components/mypage/Profile.tsx
+++ b/src/components/mypage/Profile.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import { Text } from "@/src/components/ui";
-import { profileStateAtom } from "@/src/atoms/profileStateAtom";
 import { getImageUrl, countryImg } from "@/src/modules/utils";
 import useGetProfile from "@/src/hooks/mypage/useGetProfile";
 

--- a/src/hooks/mypage/useGetProfile.ts
+++ b/src/hooks/mypage/useGetProfile.ts
@@ -1,9 +1,14 @@
-import { useQuery } from 'react-query';
-import { getProfile } from '@/src/api/mypage/profileData';
-import { ProfileStateType } from '@/src/types/mypage/profileType';
+import { useQuery } from "react-query";
+import { getProfile } from "@/src/api/mypage/profileData";
+import { ProfileStateType } from "@/src/types/mypage/profileType";
 
 export default function useGetProfile() {
-  const { data: profileData, isLoading, isError, isIdle } = useQuery<ProfileStateType>('profile', getProfile, {
+  const {
+    data: profileData,
+    isLoading,
+    isError,
+    isIdle,
+  } = useQuery<ProfileStateType>("profile", getProfile, {
     retry: 0,
   });
 

--- a/src/pages/mypage/edit/index.tsx
+++ b/src/pages/mypage/edit/index.tsx
@@ -7,12 +7,12 @@ import { useState } from "react";
 import Loading from "@/src/components/ui/loadingUI";
 import useGetProfile from "@/src/hooks/mypage/useGetProfile";
 
-export default function Edit() {
+export default function Edit(): JSX.Element {
   const [modalVisible, setModalVisible] = useState(false);
 
   const { profileData, isLoading, isError } = useGetProfile();
 
-  const onClickModal = () => {
+  const onClickModal = (): void => {
     setModalVisible((prev) => !prev);
   };
 
@@ -27,7 +27,7 @@ export default function Edit() {
             <S.GoBackArrow
               src="/back-arrow.svg"
               alt="뒤로가기"
-              onClick={() => router.push(`/mypage`)}
+              onClick={(): Promise<boolean> => router.push(`/mypage`)}
             />
             <Margin direction="row" size={13} />
             <Text.Title1 color="gray900">프로필 수정</Text.Title1>
@@ -39,7 +39,9 @@ export default function Edit() {
               <S.EditBtn
                 src="/modify.svg"
                 alt="연필"
-                onClick={() => router.push(`/mypage/edit/nickname`)}
+                onClick={(): Promise<boolean> =>
+                  router.push(`/mypage/edit/nickname`)
+                }
               />
             </S.UserBox>
           </>
@@ -53,7 +55,9 @@ export default function Edit() {
                 <S.EditBtn
                   src="/modify.svg"
                   alt="연필"
-                  onClick={() => router.push(`/mypage/edit/language`)}
+                  onClick={(): Promise<boolean> =>
+                    router.push(`/mypage/edit/language`)
+                  }
                 />
               </S.Language>
               <S.LanguageContent>
@@ -83,7 +87,9 @@ export default function Edit() {
                 <S.EditBtn
                   src="/modify.svg"
                   alt="연필"
-                  onClick={() => router.push(`/mypage/edit/introduce`)}
+                  onClick={(): Promise<boolean> =>
+                    router.push(`/mypage/edit/introduce`)
+                  }
                 />
               </S.Introduce>
               <S.IntroduceContent>
@@ -98,7 +104,9 @@ export default function Edit() {
                 <S.EditBtn
                   src="/modify.svg"
                   alt="연필"
-                  onClick={() => router.push(`/mypage/edit/interest`)}
+                  onClick={(): Promise<boolean> =>
+                    router.push(`/mypage/edit/interest`)
+                  }
                 />
               </S.Interest>
               <S.InterestBoxContainer>

--- a/src/pages/mypage/edit/index.tsx
+++ b/src/pages/mypage/edit/index.tsx
@@ -139,14 +139,14 @@ export default function Edit(): JSX.Element {
   );
 }
 
-interface IntesestBoxProps {
+type IntesestBoxProps = {
   backgroundColor: string;
-}
+};
 
-interface LanguageText {
+type LanguageText = {
   fontWeight: number;
   width: number;
-}
+};
 const S = {
   Wapper: styled.div`
     width: 100%;
@@ -229,11 +229,11 @@ const S = {
     padding-right: 6px;
   `,
   LanguageText: styled.div<LanguageText>`
-    width: ${(props) => props.width}px;
+    width: ${(props): number => props.width}px;
     color: #49494d;
     font-size: 14px;
     font-family: "Pretendard";
-    font-weight: ${(props) => props.fontWeight};
+    font-weight: ${(props): number => props.fontWeight};
   `,
   Introduce: styled.div`
     width: 452px;
@@ -263,7 +263,7 @@ const S = {
     border-radius: 40px;
     padding: 8px 15px;
     display: inline-flex;
-    background-color: ${(props) => props.backgroundColor};
+    background-color: ${(props): string => props.backgroundColor};
     margin: 8px;
   `,
 

--- a/src/pages/mypage/edit/interest.tsx
+++ b/src/pages/mypage/edit/interest.tsx
@@ -4,35 +4,33 @@ import { Text } from "@/src/components/ui";
 import SelectInterest from "@/src/components/mypage/SelectInterest";
 import { useState } from "react";
 import Modal from "@/src/components/modal";
-import instance from "@/src/api/axiosModule";
-import { useMutation,useQueryClient } from "react-query";
+import { useMutation, useQueryClient } from "react-query";
 import { postInterest } from "@/src/api/mypage/profileData";
 
-export default function Interest() {
+export default function Interest(): JSX.Element {
   const [modalVisible, setModalVisible] = useState(false);
-  const [interest,setInterest] = useState<String[]>([]);
+  const [interest, setInterest] = useState<string[]>([]);
 
   const queryClient = useQueryClient();
 
-  const onClickModal = () => {
+  const onClickModal = (): void => {
     setModalVisible((prev) => !prev);
   };
 
-  const parentFunction = (arr:any) => {
+  const parentFunction = (arr: any): void => {
     setInterest(arr);
   };
 
-   const fetchInterest = useMutation(postInterest,{
+  const fetchInterest = useMutation(postInterest, {
     onSuccess: () => {
       queryClient.invalidateQueries("profile");
     },
-  })
+  });
 
-
-  const handleSubmit = async () => {
-    fetchInterest.mutate(interest)
-    router.push(`/mypage/edit`)
-  }
+  const handleSubmit = async (): Promise<void> => {
+    fetchInterest.mutate(interest);
+    router.push(`/mypage/edit`);
+  };
 
   return (
     <>
@@ -56,7 +54,7 @@ export default function Interest() {
               완료
             </Text.Body1>
           </S.Header>
-          <SelectInterest parentFunction={parentFunction}/>
+          <SelectInterest parentFunction={parentFunction} />
         </S.Content>
         {modalVisible && (
           <Modal type="profile-back" onClickModal={onClickModal} />
@@ -92,4 +90,3 @@ const S = {
     cursor: pointer;
   `,
 };
-

--- a/src/pages/mypage/edit/introduce.tsx
+++ b/src/pages/mypage/edit/introduce.tsx
@@ -2,49 +2,48 @@ import styled from "styled-components";
 import router from "next/router";
 import { Text } from "@/src/components/ui";
 import Modal from "@/src/components/modal";
-import { useState,useCallback,useEffect } from "react";
-import { useMutation,useQueryClient } from "react-query";
+import { useState, useCallback, useEffect } from "react";
+import { useMutation, useQueryClient } from "react-query";
 import useGetProfile from "@/src/hooks/mypage/useGetProfile";
 import { postIntroduce } from "@/src/api/mypage/profileData";
 
-export default function Introduce() {
+export default function Introduce(): JSX.Element {
   const [modalVisible, setModalVisible] = useState(false);
-  const [isIntroduce,setIsIntroduce] = useState(false);
-  const [introduce,setIntroduce] = useState('');
+  const [isIntroduce, setIsIntroduce] = useState(false);
+  const [introduce, setIntroduce] = useState("");
 
   const queryClient = useQueryClient();
 
-  const onChangeIntroduce = useCallback((e: any) => {
+  const onChangeIntroduce = useCallback((e: any): void => {
     const nameCurrent = e.target.value;
     setIntroduce(nameCurrent);
   }, []);
 
-   const { profileData } = useGetProfile();
+  const { profileData } = useGetProfile();
 
   useEffect(() => {
     if (introduce.length < 2 || introduce.length > 400) {
-      setIsIntroduce(false)
+      setIsIntroduce(false);
     } else {
       setIsIntroduce(true);
     }
   }, [introduce]);
 
-  const onClickModal = () => {
+  const onClickModal = (): void => {
     setModalVisible((prev) => !prev);
   };
 
-
-  const fetchIntroduce = useMutation(postIntroduce,{
+  const fetchIntroduce = useMutation(postIntroduce, {
     onSuccess: () => {
       queryClient.invalidateQueries("profile");
     },
-  })
+  });
 
-  const handleSubmit= () => {
+  const handleSubmit = (): void => {
     fetchIntroduce.mutate(introduce);
-    router.push(`/mypage/edit`)
-  }
-  
+    router.push(`/mypage/edit`);
+  };
+
   return (
     <>
       <S.Wapper>
@@ -59,8 +58,8 @@ export default function Introduce() {
               <Text.Title1 color="gray900">자기소개</Text.Title1>
             </S.Left>
             <Text.Body1
-              color={isIntroduce ? "gray900":"gray500"} // 비활성화 상태
-              onClick={handleSubmit} 
+              color={isIntroduce ? "gray900" : "gray500"} // 비활성화 상태
+              onClick={handleSubmit}
               pointer={isIntroduce}
             >
               완료

--- a/src/pages/mypage/edit/language.tsx
+++ b/src/pages/mypage/edit/language.tsx
@@ -2,54 +2,54 @@ import styled from "styled-components";
 import router from "next/router";
 import { Margin, Text } from "@/src/components/ui";
 import Modal from "@/src/components/modal";
-import { useState,useEffect } from "react";
+import { useState, useEffect } from "react";
 import instance from "@/src/api/axiosModule";
 import SelectLanguageBox from "@/src/components/mypage/selectLanguage";
 import useGetProfile from "@/src/hooks/mypage/useGetProfile";
 import { LanguagesType } from "@/src/types/mypage/profileType";
 import Loading from "@/src/components/ui/loadingUI";
 import { postLanguage } from "@/src/api/mypage/profileData";
-import { useMutation,useQueryClient } from "react-query";
+import { useMutation, useQueryClient } from "react-query";
 
-export default function Language() {
-  const [loading, setLoading ] = useState(true);
+export default function Language(): JSX.Element {
+  const [loading, setLoading] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);
   const [btnActive, setBtnActive] = useState(false);
-  const [language,setLanguage] = useState<String[]>([]);
+  const [language, setLanguage] = useState<string[]>([]);
   const [initialLanguage, setInitialLanguage] = useState<LanguagesType[]>([]);
-  const [initialLanguageValue1,setInitialLanguageValue1] = useState('');
-  const [initialLanguageValue2,setInitialLanguageValue2] = useState('');
-  const [initialLanguageValue3,setInitialLanguageValue3] = useState('');
+  const [initialLanguageValue1, setInitialLanguageValue1] = useState("");
+  const [initialLanguageValue2, setInitialLanguageValue2] = useState("");
+  const [initialLanguageValue3, setInitialLanguageValue3] = useState("");
 
   const queryClient = useQueryClient();
   const { profileData } = useGetProfile();
 
-  const onClickModal = () => {
+  const onClickModal = (): void => {
     setModalVisible((prev) => !prev);
   };
 
-  const handleSubmit = () => {
-      fetchLanguage.mutate(language);
-      router.push(`/mypage/edit`)
+  const handleSubmit = (): void => {
+    fetchLanguage.mutate(language);
+    router.push(`/mypage/edit`);
   };
 
   const fetchLanguage = useMutation(postLanguage, {
-     onSuccess: () => {
+    onSuccess: () => {
       queryClient.invalidateQueries("profile");
     },
-  })
-  
-  const getLanguageAtIndex = (str: string, index: number) => {
+  });
+
+  const getLanguageAtIndex = (str: string, index: number): void => {
     setLanguage((prevLanguage) => {
       const updatedLanguage = [...prevLanguage];
       updatedLanguage[index] = str;
       return updatedLanguage;
     });
-};
+  };
 
-  const resetBtn = () => {
-    setLanguage([])
-    setBtnActive(false)
+  const resetBtn = (): void => {
+    setLanguage([]);
+    setBtnActive(false);
     for (let i = 0; i < 3; i++) {
       const setInitialLanguageValue = eval(`setInitialLanguageValue${i + 1}`);
       if (profileData && profileData.languages[i]) {
@@ -59,34 +59,32 @@ export default function Language() {
       }
     }
   };
- 
 
   useEffect(() => {
-   if (language[0]) {
-    setBtnActive(true)
-   }
-  },[language,btnActive])
+    if (language[0]) {
+      setBtnActive(true);
+    }
+  }, [language, btnActive]);
 
   useEffect(() => {
     if (profileData) {
-        setInitialLanguage(profileData.languages);
+      setInitialLanguage(profileData.languages);
     }
   }, [profileData]);
 
-
-useEffect(() => {
-  for (let i = 0; i < 3; i++) {
-    const setInitialLanguageValue = eval(`setInitialLanguageValue${i + 1}`);
-    if (initialLanguage[i]) {
-      setInitialLanguageValue(initialLanguage[i].interest);
-    } else {
-      setInitialLanguageValue('');
+  useEffect(() => {
+    for (let i = 0; i < 3; i++) {
+      const setInitialLanguageValue = eval(`setInitialLanguageValue${i + 1}`);
+      if (initialLanguage[i]) {
+        setInitialLanguageValue(initialLanguage[i].interest);
+      } else {
+        setInitialLanguageValue("");
+      }
     }
-  }
-  setLoading(false);
-}, [initialLanguage]);
+    setLoading(false);
+  }, [initialLanguage]);
 
-if (loading) return <Loading />
+  if (loading) return <Loading />;
 
   return (
     <>
@@ -103,7 +101,11 @@ if (loading) return <Loading />
             </S.Left>
             <Text.Body1
               color={btnActive ? "gray900" : "gray500"}
-              onClick={btnActive ? handleSubmit : () => alert("언어를 선택해주세요")}
+              onClick={
+                btnActive
+                  ? handleSubmit
+                  : (): void => alert("언어를 선택해주세요")
+              }
               pointer
             >
               완료
@@ -112,17 +114,33 @@ if (loading) return <Loading />
           <S.SelectBox>
             <Text.Body5 color="gray700">1순위</Text.Body5>
             <Margin direction="column" size={8} />
-            <SelectLanguageBox getLanguageAtIndex={(str) => getLanguageAtIndex(str, 0)} initialLanguage={initialLanguageValue1} idx={0}/>
+            <SelectLanguageBox
+              getLanguageAtIndex={(str): void => getLanguageAtIndex(str, 0)}
+              initialLanguage={initialLanguageValue1}
+              idx={0}
+            />
 
             <Margin direction="column" size={24} />
-            <Text.Body5 color= { language[0]!==''? "gray700" : "gray500"}>2순위</Text.Body5>
+            <Text.Body5 color={language[0] !== "" ? "gray700" : "gray500"}>
+              2순위
+            </Text.Body5>
             <Margin direction="column" size={8} />
-            <SelectLanguageBox getLanguageAtIndex={(str) => getLanguageAtIndex(str, 1)} initialLanguage={initialLanguageValue2} idx={1}/>
+            <SelectLanguageBox
+              getLanguageAtIndex={(str): void => getLanguageAtIndex(str, 1)}
+              initialLanguage={initialLanguageValue2}
+              idx={1}
+            />
 
             <Margin direction="column" size={24} />
-            <Text.Body5 color={ language[1]!==''? "gray700" : "gray500"}>3순위</Text.Body5>
+            <Text.Body5 color={language[1] !== "" ? "gray700" : "gray500"}>
+              3순위
+            </Text.Body5>
             <Margin direction="column" size={8} />
-            <SelectLanguageBox getLanguageAtIndex={(str) => getLanguageAtIndex(str, 2)} initialLanguage={initialLanguageValue3} idx={2} />
+            <SelectLanguageBox
+              getLanguageAtIndex={(str): void => getLanguageAtIndex(str, 2)}
+              initialLanguage={initialLanguageValue3}
+              idx={2}
+            />
           </S.SelectBox>
           <S.ResetBox>
             <S.ResetBtn>
@@ -179,7 +197,7 @@ const S = {
   ResetBox: styled.div`
     display: flex;
     justify-content: flex-end;
-    margin-top : 50px;
+    margin-top: 50px;
   `,
   ResetBtn: styled.button`
     width: 79px;

--- a/src/pages/mypage/edit/nickname.tsx
+++ b/src/pages/mypage/edit/nickname.tsx
@@ -9,6 +9,7 @@ import { ProfileUpdateType } from "@/src/types/mypage/profileType";
 import { useMutation, useQuery, useQueryClient } from "react-query";
 import { postUpdateProfile } from "@/src/api/mypage/updateProfile";
 import { getProfile } from "@/src/api/mypage/profileData";
+import { checkNicknameAvailable } from "../../../api/auth/emailAPI";
 
 export default function Nickname(): JSX.Element {
   const [modalVisible, setModalVisible] = useState(false);
@@ -70,6 +71,7 @@ export default function Nickname(): JSX.Element {
   const onChangeName = (e: any): void => {
     const nameRegex = /^[가-힣a-zA-Z]{2,10}$/;
     const nameCurrent = e.target.value;
+
     if (nameCurrent === "") {
       setName(profileData.nickname);
       setIsName(true);
@@ -77,10 +79,9 @@ export default function Nickname(): JSX.Element {
     } else if (!nameRegex.test(nameCurrent)) {
       setNameMessage("한글/영어 2글자 이상 10글자 이하");
       setIsName(false);
-    } else if (nameRegex) {
-      setNameMessage("사용 가능한 형식입니다.");
+    } else {
       setName(nameCurrent);
-      setIsName(true);
+      checkNickname(nameCurrent);
     }
   };
 
@@ -127,6 +128,18 @@ export default function Nickname(): JSX.Element {
 
   const handleUploadButtonClick = (): void => {
     fileInputRef.current?.click();
+  };
+
+  // 닉네임 중복 확인 기능
+  const checkNickname = async (name: string): Promise<void> => {
+    try {
+      await checkNicknameAvailable(name);
+      setNameMessage("사용 가능한 닉네임입니다.");
+      setIsName(true);
+    } catch {
+      setNameMessage("이미 사용 중인 닉네임입니다.");
+      setIsName(false);
+    }
   };
 
   const onClickComplete = async (): Promise<void> => {

--- a/src/pages/mypage/edit/nickname.tsx
+++ b/src/pages/mypage/edit/nickname.tsx
@@ -253,7 +253,7 @@ const S = {
     cursor: pointer;
   `,
   CloseIcon: styled.img<{ cancel: boolean }>`
-    display: ${({ cancel }) => (cancel ? "auto" : "none")};
+    display: ${({ cancel }): string => (cancel ? "auto" : "none")};
     width: 24px;
     height: 24px;
     border-radius: 100px;

--- a/src/pages/mypage/edit/nickname.tsx
+++ b/src/pages/mypage/edit/nickname.tsx
@@ -77,7 +77,9 @@ export default function Nickname(): JSX.Element {
       setIsName(true);
       setNameMessage("");
     } else if (!nameRegex.test(nameCurrent)) {
-      setNameMessage("한글/영어 2글자 이상 10글자 이하");
+      setNameMessage(
+        "한글/영어 2글자 이상 10글자 이하, 숫자와 특수기호 사용 금지"
+      );
       setIsName(false);
     } else {
       setName(nameCurrent);

--- a/src/pages/mypage/edit/nickname.tsx
+++ b/src/pages/mypage/edit/nickname.tsx
@@ -10,7 +10,7 @@ import { useMutation, useQuery, useQueryClient } from "react-query";
 import { postUpdateProfile } from "@/src/api/mypage/updateProfile";
 import { getProfile } from "@/src/api/mypage/profileData";
 
-export default function Nickname() {
+export default function Nickname(): JSX.Element {
   const [modalVisible, setModalVisible] = useState(false);
   const [name, setName] = useState<string>("");
   const [nameMessage, setNameMessage] = useState<string>("");
@@ -67,7 +67,7 @@ export default function Nickname() {
   if (isError || isIdle) return <>에러</>;
   if (fileError) alert("업로드 가능한 이미지 크기 제한을 초과했습니다.");
 
-  const onChangeName = (e: any) => {
+  const onChangeName = (e: any): void => {
     const nameRegex = /^[가-힣a-zA-Z]{2,10}$/;
     const nameCurrent = e.target.value;
     if (nameCurrent === "") {
@@ -84,29 +84,29 @@ export default function Nickname() {
     }
   };
 
-  const onClickModal = () => {
+  const onClickModal = (): void => {
     setModalVisible((prev) => !prev);
   };
 
-  const onLoadFile = (e: any) => {
+  const onLoadFile = (e: any): Promise<void> => {
     const reader = new FileReader();
     reader.readAsDataURL(e);
     return new Promise<void>((resolve) => {
-      reader.onload = () => {
+      reader.onload = (): void => {
         setImage(reader.result);
         resolve();
       };
     });
   };
 
-  const deleteFileImage = () => {
+  const deleteFileImage = (): void => {
     URL.revokeObjectURL(image);
     setImage(null);
     setImageDelete(profileData.image !== null);
     setImageFile(null);
   };
 
-  const handleFileUpload = (event: any) => {
+  const handleFileUpload = (event: any): void => {
     const imageFile = event.target.files?.[0];
     const formData = new FormData();
     formData.append("image", imageFile);
@@ -125,11 +125,11 @@ export default function Nickname() {
     }
   };
 
-  const handleUploadButtonClick = () => {
+  const handleUploadButtonClick = (): void => {
     fileInputRef.current?.click();
   };
 
-  const onClickComplete = async () => {
+  const onClickComplete = async (): Promise<void> => {
     if (!isName) return;
     if (name === "") {
       setName(profileData.nickname);
@@ -171,7 +171,7 @@ export default function Nickname() {
                 ref={fileInputRef}
                 type="file"
                 accept=".jpeg, .jpg, .png"
-                onChange={(e) => {
+                onChange={(e): void => {
                   handleFileUpload(e);
                 }}
                 style={{ display: "none" }}
@@ -185,7 +185,7 @@ export default function Nickname() {
                 cancel={image}
                 src="/mypage/cancel.png"
                 alt="변경 아이콘"
-                onClick={(e) => {
+                onClick={(e): void => {
                   e.stopPropagation();
                   deleteFileImage();
                 }}

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -137,8 +137,8 @@ const S = {
     display: flex;
     justify-content: center;
     align-items: center;
-    border: 1px solid ${(props) => props.Color || "#6c6c70"};
-    background-color: ${(props) => props.Color || "white"};
+    border: 1px solid ${(props): string => props.Color || "#6c6c70"};
+    background-color: ${(props): string => props.Color || "white"};
     border-radius: 8px;
   `,
   RegisterDrop: styled.div`

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 import Loading from "@/src/components/ui/loadingUI";
 import useGetProfile from "@/src/hooks/mypage/useGetProfile";
 
-export default function Mypage() {
+export default function Mypage(): JSX.Element {
   const [editText, setEditText] = useState(true);
   const [isRegisterDropVisible, setIsRegisterDropVisible] = useState(false);
 
@@ -25,7 +25,7 @@ export default function Mypage() {
     }
   }, [profileData]);
 
-  const handleLogout = () => {
+  const handleLogout = (): void => {
     localStorage.clear();
     router.push("/auth/login");
   };
@@ -45,13 +45,13 @@ export default function Mypage() {
             {editText ? (
               <S.EditBtn
                 Color="#FF812E"
-                onClick={() => router.push(`/mypage/edit`)}
+                onClick={(): Promise<boolean> => router.push(`/mypage/edit`)}
               >
                 <Text.Caption1
                   color="white"
                   pointer
-                  onMouseEnter={() => setIsRegisterDropVisible(true)}
-                  onMouseLeave={() => setIsRegisterDropVisible(false)}
+                  onMouseEnter={(): void => setIsRegisterDropVisible(true)}
+                  onMouseLeave={(): void => setIsRegisterDropVisible(false)}
                 >
                   등록
                 </Text.Caption1>
@@ -64,7 +64,9 @@ export default function Mypage() {
                 )}
               </S.EditBtn>
             ) : (
-              <S.EditBtn onClick={() => router.push(`/mypage/edit`)}>
+              <S.EditBtn
+                onClick={(): Promise<boolean> => router.push(`/mypage/edit`)}
+              >
                 <Text.Caption1 color="gray700" pointer>
                   수정
                 </Text.Caption1>
@@ -76,7 +78,7 @@ export default function Mypage() {
             <Text.Body1
               color="gray900"
               pointer
-              onClick={() => router.push(`/mypage/postList`)}
+              onClick={(): Promise<boolean> => router.push(`/mypage/postList`)}
             >
               내가 쓴 게시글
             </Text.Body1>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,0 +1,386 @@
+import Modal from "@/src/components/modal";
+import { Text, Margin } from "@/src/components/ui";
+import styled from "styled-components";
+import { useRouter } from "next/router";
+import { useState, useEffect } from "react";
+import Loading from "@/src/components/ui/loadingUI";
+import instance from "@/src/api/axiosModule";
+import { getImageUrl, countryImg } from "@/src/modules/utils";
+import { ProfileStateType } from "@/src/types/mypage/profileType";
+
+export default function Edit(): JSX.Element {
+  const [modalVisible, setModalVisible] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+  const [profileData, setProfileData] = useState<ProfileStateType>();
+
+  const router = useRouter();
+  const userID = router.query["userID"];
+
+  const getProfile = async (): Promise<void> => {
+    try {
+      const res = await instance.get(`/profile/${userID}`);
+      setProfileData(res.data.data);
+      setIsLoading(false);
+    } catch (err) {
+      setIsError(true);
+      throw err;
+    }
+  };
+  useEffect(() => {
+    if (userID) getProfile();
+  }, [userID]);
+
+  const onClickModal = (): void => {
+    setModalVisible((prev) => !prev);
+  };
+
+  const sendNote = (): void => {
+    // 연주님이 추가 필요
+    // userID는 위에서 가져오면 돼요!
+    // router.push('/messages/~)
+  };
+  if (isLoading) return <Loading />;
+  if (isError) return <>에러</>;
+
+  return (
+    <>
+      <S.Wapper>
+        <S.Content>
+          <S.Header>
+            <S.GoBackArrow
+              src="/back-arrow.svg"
+              alt="뒤로가기"
+              onClick={(): Promise<boolean> => router.push(`/mypage`)}
+            />
+            <Margin direction="row" size={13} />
+            <Text.Title1 color="gray900">프로필</Text.Title1>
+          </S.Header>
+          <>
+            <S.UserBox>
+              <S.UserImgBox>
+                <S.UserProfileImg
+                  src={
+                    profileData &&
+                    (profileData.image
+                      ? profileData.image
+                      : getImageUrl("기본"))
+                  }
+                  alt="프로필"
+                />
+                <S.UserFlagImg
+                  src={profileData && countryImg(profileData.nation)}
+                  alt="국기"
+                />
+              </S.UserImgBox>
+              <S.UserInfoBox>
+                <S.UserNicknameAndSex>
+                  <Text.Body1 color="gray900">
+                    {profileData && profileData.nickname}
+                  </Text.Body1>
+                  <S.UserSexImg
+                    src={
+                      profileData && profileData.gender
+                        ? "/mypage/female.svg"
+                        : "/mypage/male.svg"
+                    }
+                    alt="성별"
+                  />
+                </S.UserNicknameAndSex>
+                <Text.Body6 color="gray800">
+                  {profileData && profileData.nation}
+                </Text.Body6>
+              </S.UserInfoBox>
+            </S.UserBox>
+          </>
+
+          {/* <S.EditList>
+            <Margin direction="column" size={32} />
+
+            <S.Column>
+              <S.Language>
+                <Text.Body1 color="gray900">사용언어</Text.Body1>
+                <S.EditBtn
+                  src="/modify.svg"
+                  alt="연필"
+                  onClick={(): Promise<boolean> =>
+                    router.push(`/mypage/edit/language`)
+                  }
+                />
+              </S.Language>
+              <S.LanguageContent>
+                {profileData &&
+                  profileData.languages.map((v) => (
+                    <S.LanguageChartContent key={v.order}>
+                      <S.LanguageChart src={`/mypage/language${v.order}.svg`} />
+                      <S.LanguageText fontWeight={550} width={28}>
+                        {v.interest.substring(0, 2)}{" "}
+                      </S.LanguageText>
+                      <S.LanguageText
+                        fontWeight={400}
+                        width={262}
+                        color="orange500"
+                      >
+                        {v.interest.substring(2)}
+                      </S.LanguageText>
+                    </S.LanguageChartContent>
+                  ))}
+              </S.LanguageContent>
+            </S.Column>
+
+            <Margin direction="column" size={32} />
+            <S.Column>
+              <S.Introduce>
+                <Text.Body1 color="gray900">자기소개</Text.Body1>
+                <S.EditBtn
+                  src="/modify.svg"
+                  alt="연필"
+                  onClick={(): Promise<boolean> =>
+                    router.push(`/mypage/edit/introduce`)
+                  }
+                />
+              </S.Introduce>
+              <S.IntroduceContent>
+                {profileData && profileData.introduce}
+              </S.IntroduceContent>
+            </S.Column>
+
+            <Margin direction="column" size={32} />
+            <S.Column>
+              <S.Interest>
+                <Text.Body1 color="gray900">관심사</Text.Body1>
+                <S.EditBtn
+                  src="/modify.svg"
+                  alt="연필"
+                  onClick={(): Promise<boolean> =>
+                    router.push(`/mypage/edit/interest`)
+                  }
+                />
+              </S.Interest>
+              <S.InterestBoxContainer>
+                {profileData &&
+                  profileData.interests.map((item, index) => {
+                    const isLastItemInRow = (index + 1) % 3 === 0;
+
+                    return (
+                      <S.ShowInterest key={item}>
+                        <S.InterestBox backgroundColor="#FFF3EB">
+                          <Text.Body6 color="gray900" pointer>
+                            {item}
+                          </Text.Body6>
+                        </S.InterestBox>
+                        {isLastItemInRow && (
+                          <Margin direction="column" size={0} />
+                        )}
+                      </S.ShowInterest>
+                    );
+                  })}
+              </S.InterestBoxContainer>
+            </S.Column>
+          </S.EditList> */}
+          <S.Note onClick={sendNote}>쪽지 보내기</S.Note>
+        </S.Content>
+        {modalVisible && (
+          <Modal type="profile-back" onClickModal={onClickModal} />
+        )}
+      </S.Wapper>
+    </>
+  );
+}
+
+interface IntesestBoxProps {
+  backgroundColor: string;
+}
+
+interface LanguageText {
+  fontWeight: number;
+  width: number;
+}
+const S = {
+  Wapper: styled.div`
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    /* border: 1px solid red; */
+  `,
+  Content: styled.div`
+    padding: 0 24px;
+  `,
+  Header: styled.div`
+    display: flex;
+    padding: 14px 0;
+  `,
+  GoBackArrow: styled.img`
+    cursor: pointer;
+  `,
+
+  UserBox: styled.div`
+    display: flex;
+    align-items: center;
+    /* border-bottom: 1px solid #eeeef2; */
+    gap: 14px;
+    position: relative;
+  `,
+  UserImgBox: styled.div`
+    width: 56px;
+    height: 56px;
+    position: relative;
+  `,
+  UserProfileImg: styled.img`
+    width: 56px;
+    height: 56px;
+    position: absolute;
+    border-radius: 100px;
+    border: 1px solid #eeeef2;
+  `,
+  UserFlagImg: styled.img`
+    width: 22px;
+    height: 22px;
+    position: absolute;
+    border: 1px solid white;
+    background-color: white;
+    border-radius: 100px;
+    right: 0%;
+    bottom: 0%;
+    z-index: 1;
+  `,
+  UserInfoBox: styled.div`
+    width: 340px;
+    height: 86px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  `,
+  UserNicknameAndSex: styled.div`
+    display: flex;
+  `,
+  UserSexImg: styled.img`
+    width: 16px;
+    height: 16px;
+    padding-left: 4px;
+    margin: 3px 0px;
+  `,
+
+  DropBubbleHigh: styled.div`
+    position: absolute;
+    top: 63px;
+    left: 435px;
+    border-bottom: 8px solid #303033;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+  `,
+
+  DropBubbleLow: styled.div`
+    width: 153px;
+    height: 42px;
+    background-color: #303033;
+    border-radius: 8px;
+    position: absolute;
+    top: 70px;
+    left: 300px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  `,
+
+  RegisterBtn: styled.button`
+    width: 45px;
+    height: 33px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: #ff812e;
+    border-radius: 8px;
+  `,
+
+  EditList: styled.div`
+    width: 452px;
+    display: flex;
+    flex-direction: column;
+  `,
+  Language: styled.div`
+    width: 452px;
+    display: flex;
+    justify-content: space-between;
+  `,
+  LanguageContent: styled.div`
+    margin-top: 16px;
+    padding: 16px, 24px, 24px, 24px;
+  `,
+  LanguageChartContent: styled.div`
+    display: flex;
+    flex-direction: row;
+    padding-bottom: 6px;
+  `,
+  LanguageChart: styled.img`
+    width: 18px;
+    height: 18px;
+    padding-right: 6px;
+  `,
+  LanguageText: styled.div<LanguageText>`
+    width: ${(props) => props.width}px;
+    color: #49494d;
+    font-size: 14px;
+    font-family: "Pretendard";
+    font-weight: ${(props) => props.fontWeight};
+  `,
+  Introduce: styled.div`
+    width: 452px;
+    display: flex;
+    justify-content: space-between;
+  `,
+  IntroduceContent: styled.div`
+    padding-top: 16px;
+    font-size: 16px;
+    line-height: 140%;
+    color: theme.color.gray900;
+  `,
+  InterestBoxContainer: styled.div`
+    width: 80%;
+  `,
+  Interest: styled.div`
+    width: 452px;
+    display: flex;
+    justify-content: space-between;
+  `,
+  ShowInterest: styled.div`
+    display: inline-flex;
+    flex-direction: column;
+  `,
+  InterestBox: styled.div<IntesestBoxProps>`
+    cursor: pointer;
+    border-radius: 40px;
+    padding: 8px 15px;
+    display: inline-flex;
+    background-color: ${(props) => props.backgroundColor};
+    margin: 8px;
+  `,
+
+  Column: styled.div`
+    display: flex;
+    flex-direction: column;
+  `,
+  Note: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 17px 16px;
+    gap: 6px;
+    position: fixed;
+    width: 404px;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: 32px;
+
+    /* main_orange/orange500 */
+    background: #ff812e;
+    border-radius: 8px;
+    font-family: "Pretendard";
+    font-style: normal;
+    font-weight: 700;
+    font-size: 16px;
+    color: #ffffff;
+  `,
+};

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -320,11 +320,11 @@ const S = {
     padding-right: 6px;
   `,
   LanguageText: styled.div<LanguageText>`
-    width: ${(props) => props.width}px;
+    width: ${(props): number => props.width}px;
     color: #49494d;
     font-size: 14px;
     font-family: "Pretendard";
-    font-weight: ${(props) => props.fontWeight};
+    font-weight: ${(props): number => props.fontWeight};
   `,
   Introduce: styled.div`
     width: 452px;
@@ -354,7 +354,7 @@ const S = {
     border-radius: 40px;
     padding: 8px 15px;
     display: inline-flex;
-    background-color: ${(props) => props.backgroundColor};
+    background-color: ${(props): string => props.backgroundColor};
     margin: 8px;
   `,
 


### PR DESCRIPTION
## PR 내용

1. 리턴 타입 추가  (10개 파일 변화) 

2. profile 페이지 추가 : 쿼리로 userID 받아옴. 
<img width="555" alt="image" src="https://github.com/Wingle-SMWU/Wingle-Frontend/assets/113181934/760fed93-17b7-4106-b256-bcb81cb1769c">


**알아 두어야 할 점 :** 
서버에서 언어, 관심사, 자기소개가 없어서 현재는 주석 처리함. 추후 반영 예정 

 @yxunakim84  유나님, 타인 프로필 보여주는 community/detail 등 페이지에서  
 ex ) router.push(/profile?userID=10(사용자아이디)) 이렇게 보내주세요. 

@yeonkr  연주님, 쪽지 기능 보내는 기능은 직접 작성 부탁드려요. 
sendNote 함수에 작성하시면 돼요.
 
 
 3. 닉네임 중복시 알람창 추가 
 

