### PR TITLE
fix: 커뮤니티 관련 페이지 다국어처리 삭제

### DIFF
--- a/src/components/community/list/header.tsx
+++ b/src/components/community/list/header.tsx
@@ -4,7 +4,6 @@ import { useQuery } from "react-query";
 import styled from "styled-components";
 import Image from "next/image";
 import { useRouter } from "next/router";
-import { useTranslation } from "react-i18next";
 
 type Tab = {
   tab?: boolean;
@@ -31,8 +30,6 @@ export default function Header({
 
   const router = useRouter();
 
-  const { t } = useTranslation();
-
   if (isLoading) return <div>로딩중</div>;
   if (isError || isIdle) return <div>에러</div>;
 
@@ -51,10 +48,10 @@ export default function Header({
                 router.push("/mypage");
               }}
             />
-            <Text.Title1 color="gray900">{t("myPage:mypost")}</Text.Title1>
+            <Text.Title1 color="gray900">내가 쓴 게시글</Text.Title1>
           </>
         ) : (
-          <Text.Title1 color="gray900">{t("community:main.head")}</Text.Title1>
+          <Text.Title1 color="gray900">커뮤니티</Text.Title1>
         )}
       </S.Header>
       <S.HeaderBar>

--- a/src/components/layout/Navigation/index.tsx
+++ b/src/components/layout/Navigation/index.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import { Text } from "../../ui";
 import useGetProfile from "@/src/hooks/mypage/useGetProfile";
 import { theme } from "@/src/styles/theme";
-import { useTranslation } from "react-i18next";
 
 type Profile = {
   isRadius: boolean;
@@ -15,27 +14,25 @@ type Tab = {
 };
 
 export default function Navigation(props: Tab) {
-  const { t } = useTranslation();
-
   const router = useRouter();
   const menu = router.asPath;
 
   const { profileData } = useGetProfile();
   const NavigationMenuArr = [
     {
-      name: `${t("navbar:community")}`,
+      name: "커뮤니티",
       page: "/community",
       normalImg: "/community/list/comu-normal.svg",
       disableImg: "/community/list/comu-disable.svg",
     },
     {
-      name: `${t("navbar:message")}`,
+      name: "쪽지",
       page: "/messages",
       normalImg: "/community/list/message-normal.svg",
       disableImg: "/community/list/message-disable.svg",
     },
     {
-      name: `${t("navbar:mypage")}`,
+      name: "마이페이지",
       page: "/mypage",
       normalImg: `
       ${
@@ -58,7 +55,7 @@ export default function Navigation(props: Tab) {
         {NavigationMenuArr.map((el) => (
           <S.NavigationMenu key={el.name} href={el.page}>
             <S.NavigationMenuImg
-              isRadius={el.name === `${t("navbar:mypage")}`}
+              isRadius={el.name === "마이페이지"}
               isActive={props.tab === "mypage"}
               src={menu.includes(el.page) ? el.normalImg : el.disableImg}
             />

--- a/src/pages/community/create.tsx
+++ b/src/pages/community/create.tsx
@@ -3,27 +3,14 @@ import Modal from "@/src/components/modal";
 import { Text } from "@/src/components/ui";
 import { useRouter } from "next/router";
 import { ChangeEvent, useState } from "react";
-import { useTranslation } from "react-i18next";
 import { useMutation, useQueryClient } from "react-query";
 import styled from "styled-components";
-import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { GetStaticProps } from "next";
-
-export const getStaticProps: GetStaticProps = async ({
-  locale = "en" || "ko",
-}) => {
-  return {
-    props: { ...(await serverSideTranslations(locale, ["community"])) },
-  };
-};
 
 export default function Create(): JSX.Element {
   const router = useRouter();
   const { tab: currentTab, forumId } = router.query;
   const [contents, setContents] = useState("");
   const [modalVisible, setModalVisible] = useState(false);
-
-  const { t } = useTranslation();
 
   const queryClient = useQueryClient();
 
@@ -96,13 +83,13 @@ export default function Create(): JSX.Element {
             color={contents ? "gray900" : "gray500"}
             onClick={(): void => updateArticle.mutate()}
           >
-            {t("community:write.done")}
+            등록
           </Text.Body1>
         </S.CreateButton>
       </S.Header>
       <S.Body>
         <S.Contents
-          placeholder={t("community:write.leavepost")}
+          placeholder="자유롭게 글을 작성해보세요!"
           onChange={onChangeContents}
           maxLength={3000}
           value={contents}

--- a/src/pages/community/index.tsx
+++ b/src/pages/community/index.tsx
@@ -14,15 +14,15 @@ import styled from "styled-components";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { GetStaticProps } from "next";
 
-export const getStaticProps: GetStaticProps = async ({
-  locale = "en" || "ko",
-}) => {
-  return {
-    props: {
-      ...(await serverSideTranslations(locale, ["community", "navbar"])),
-    },
-  };
-};
+// export const getStaticProps: GetStaticProps = async ({
+//   locale = "en" || "ko",
+// }) => {
+//   return {
+//     props: {
+//       ...(await serverSideTranslations(locale, ["community", "navbar"])),
+//     },
+//   };
+// };
 
 export default function Community(): JSX.Element {
   const router = useRouter();


### PR DESCRIPTION
## PR 내용
커뮤니티 관련 페이지 다국어처리 삭제
serverSideTranslations 함수로 인해 단일 페이지인 커뮤니티로 돌아갈 때마다 새로고침되어 tab 기록이 유지되지 않고 자유 탭으로 설정됨

## branch
- [ ] feat -> develop


## 리뷰
팀원들이 집중해서 검토해야 할 부분을 작성해주세요.
